### PR TITLE
move token container to queryString to header#18

### DIFF
--- a/functions/src/@types/API/exec.d.ts
+++ b/functions/src/@types/API/exec.d.ts
@@ -3,14 +3,15 @@ declare module 'homeMaidApi' {
 
   export interface execRequest extends express.Request {
     body: {
-      // API TOKEN(WIP)
-      token?: string;
-
       // Enable Light
       isTurnOn?: true;
 
       // Enable huequica's Room Air Conditioner, Light
       withRoom?: true;
+    };
+
+    headers: {
+      authorization?: string;
     };
   }
 }

--- a/functions/src/@types/API/global.d.ts
+++ b/functions/src/@types/API/global.d.ts
@@ -1,0 +1,7 @@
+import { IncomingHttpHeaders } from 'http';
+
+declare module 'http' {
+  interface IncomingHttpHeaders {
+    authorization?: string;
+  }
+}

--- a/functions/src/@types/API/hello.d.ts
+++ b/functions/src/@types/API/hello.d.ts
@@ -1,8 +1,8 @@
 declare module 'homeMaidApi' {
   import express from 'express';
   export interface helloRequest extends express.Request {
-    query: {
-      token?: string;
+    headers: {
+      authorization?: string;
     };
   }
 }

--- a/functions/src/API.ts
+++ b/functions/src/API.ts
@@ -39,7 +39,7 @@ app.get(
 
 app.post(
   '/exec',
-  header('token').notEmpty(),
+  header('authorization').notEmpty(),
   async (req: execRequest, res: express.Response) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {

--- a/functions/src/API.ts
+++ b/functions/src/API.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { body, check, validationResult } from 'express-validator';
+import { body, header, validationResult } from 'express-validator';
 import { execRequest, helloRequest } from 'homeMaidApi';
 import { fetchUserFromToken } from '@/service/firestore/fetchUserFromToken';
 import exec from '@/service/exec';
@@ -10,20 +10,20 @@ app.use(express.json({}));
 
 app.get(
   '/hello',
-  [check('token').notEmpty()],
+  header('authorization').notEmpty(),
   async (req: helloRequest, res: express.Response) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
       return res.status(401).send({ statusCode: 401, message: errors.array() });
     }
 
-    if (!req.query.token) {
+    if (!req.headers.authorization) {
       return res
         .status(401)
-        .send({ statusCode: 500, message: 'missing token' });
+        .send({ statusCode: 401, message: 'missing token' });
     }
 
-    const userResponse = await fetchUserFromToken(req.query.token);
+    const userResponse = await fetchUserFromToken(req.headers.authorization);
     if (!userResponse) {
       return res
         .status(401)

--- a/functions/src/API.ts
+++ b/functions/src/API.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { body, header, validationResult } from 'express-validator';
+import { header, validationResult } from 'express-validator';
 import { execRequest, helloRequest } from 'homeMaidApi';
 import { fetchUserFromToken } from '@/service/firestore/fetchUserFromToken';
 import exec from '@/service/exec';
@@ -39,20 +39,20 @@ app.get(
 
 app.post(
   '/exec',
-  [body('token').notEmpty()],
+  header('token').notEmpty(),
   async (req: execRequest, res: express.Response) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
       return res.status(401).send({ statusCode: errors.array() });
     }
 
-    if (!req.body.token) {
+    if (!req.headers.authorization) {
       return res
         .status(401)
         .send({ statusCode: 401, message: 'missing token' });
     }
 
-    const userResponse = await fetchUserFromToken(req.body.token);
+    const userResponse = await fetchUserFromToken(req.headers.authorization);
     if (!userResponse) {
       return res
         .status(401)


### PR DESCRIPTION
- close #18

- `token` という queryString が `authorization` というヘッダーに移りました
- **破壊変更なのでAPIユーザーの更新作業が必要です**

